### PR TITLE
Dont crash if credential not found

### DIFF
--- a/AdysTech.CredentialManager/AdysTech.CredentialManager.nuspec
+++ b/AdysTech.CredentialManager/AdysTech.CredentialManager.nuspec
@@ -10,14 +10,14 @@
     <projectUrl>https://github.com/AdysTech/CredentialManager</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
-    <releaseNotes>C# wrapper around CredWrite / CredRead functions to store and retrieve from Windows Credential Store. Windows OS comes equipped with a very secure robust Credential Manager from Windows Xp onwards, and good set of APIs to interact with it. 
+    <releaseNotes>C# wrapper around CredWrite / CredRead functions to store and retrieve from Windows Credential Store. Windows OS comes equipped with a very secure robust Credential Manager from Windows Xp onwards, and good set of APIs to interact with it.
 However .Net framework did not provide any standard way to interact with this vault until Windows 10.          Need: Many web services and REST Urls use basic authentication. .Net does not have a way to generate basic auth text (username:password encoded in Base64) for the current logged in user, with their credentials. ICredential.GetCredential (uri, "Basic") does not provide a way to get current user security context either as it will expose the current password in plain text. So only way to retrieve Basic auth text is to prompt the user for the credentials and storing it, or assume some stored credentials in Windows store, and retrieving it. The library provides
           1. Prompt user for Credentials
           2. Save Credentials
           3. Retrieve saved Credentials
 Based on Microsoft Peer Channel blog (WCF team) post from 2005
 	</releaseNotes>
-    <copyright>Copyright 2017</copyright>
+    <copyright>Copyright 2018</copyright>
     <tags>Credential CredentialManager Basic Authentication BasicAuthentication Password UserName</tags>
   </metadata>
 </package>

--- a/AdysTech.CredentialManager/CredentialManager.cs
+++ b/AdysTech.CredentialManager/CredentialManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Net;
@@ -29,7 +29,7 @@ namespace AdysTech.CredentialManager
             int errorcode = 0;
             uint authPackage = 0;
 
-            IntPtr outCredBuffer = new IntPtr();
+            var outCredBuffer = new IntPtr();
             uint outCredSize;
             var flags = NativeCode.PromptForWindowsCredentialsFlags.GenericCredentials | 
                     NativeCode.PromptForWindowsCredentialsFlags.EnumerateCurrentUser;
@@ -86,8 +86,8 @@ namespace AdysTech.CredentialManager
 
         private static bool ParseUserName(string usernameBuf, int maxUserName, int maxDomain, out string user, out string domain)
         {
-            StringBuilder userBuilder = new StringBuilder();
-            StringBuilder domainBuilder = new StringBuilder();
+            var userBuilder = new StringBuilder();
+            var domainBuilder = new StringBuilder();
             user = String.Empty;
             domain = String.Empty;
 
@@ -105,65 +105,55 @@ namespace AdysTech.CredentialManager
 
         internal static bool PromptForCredentials(string target, ref bool save, out string user, out string password, out string domain)
         {
-            NativeCode.CredentialUIInfo credUI = new NativeCode.CredentialUIInfo();
-            credUI.hwndParent = IntPtr.Zero;
-            credUI.pszMessageText = " ";
-            credUI.pszCaptionText = " ";
-            credUI.hbmBanner = IntPtr.Zero;
-            credUI.hwndParent = IntPtr.Zero;
+            var credUI = new NativeCode.CredentialUIInfo
+            {
+                hwndParent = IntPtr.Zero, pszMessageText = " ", pszCaptionText = " ", hbmBanner = IntPtr.Zero
+            };
             return PromptForCredentials(target, credUI, ref save, out user, out password, out domain);
         }
 
-        internal static bool PromptForCredentials(string target, ref bool save, string Message, string Caption, out string user, out string password, out string domain)
+        internal static bool PromptForCredentials(string target, ref bool save, string message, string caption, out string user, out string password, out string domain)
         {
-            NativeCode.CredentialUIInfo credUI = new NativeCode.CredentialUIInfo();
-            credUI.pszMessageText = Message;
-            credUI.pszCaptionText = Caption;
-            credUI.hwndParent = IntPtr.Zero;
-            credUI.hbmBanner = IntPtr.Zero;
+            var credUI = new NativeCode.CredentialUIInfo
+            {
+                pszMessageText = message,
+                pszCaptionText = caption,
+                hwndParent = IntPtr.Zero,
+                hbmBanner = IntPtr.Zero
+            };
             return PromptForCredentials(target, credUI, ref save, out user, out password, out domain);
         }
 
         /// <summary>
         /// Opens OS Version specific Window prompting for credentials
         /// </summary>
-        /// <param name="Target">A descriptive text for where teh credentials being asked are used for</param>
+        /// <param name="target">A descriptive text for where teh credentials being asked are used for</param>
         /// <param name="save">Whether or not to offer the checkbox to save the credentials</param>
         /// <returns>NetworkCredential object containing the user name, </returns>
-        public static NetworkCredential PromptForCredentials(string Target, ref bool save)
+        public static NetworkCredential PromptForCredentials(string target, ref bool save)
         {
-            var username = String.Empty;
-            var passwd = String.Empty;
-            var domain = String.Empty;
-
-            if (!PromptForCredentials(Target, ref save, out username, out passwd, out domain))
-                return null;
-            return new NetworkCredential(username, passwd, domain);
+            string username, passwd, domain;
+            return PromptForCredentials(target, ref save, out username, out passwd, out domain) ? new NetworkCredential(username, passwd, domain) : null;
         }
 
         /// <summary>
         /// Opens OS Version specific Window prompting for credentials
         /// </summary>
-        /// <param name="Target">A descriptive text for where teh credentials being asked are used for</param>
+        /// <param name="target">A descriptive text for where teh credentials being asked are used for</param>
         /// <param name="save">Whether or not to offer the checkbox to save the credentials</param>
-        /// <param name="Message">A brief message to display in the dialog box</param>
-        /// <param name="Caption">Title for the dialog box</param>
+        /// <param name="message">A brief message to display in the dialog box</param>
+        /// <param name="caption">Title for the dialog box</param>
         /// <returns>NetworkCredential object containing the user name, </returns>
-        public static NetworkCredential PromptForCredentials(string Target, ref bool save, string Message, string Caption)
+        public static NetworkCredential PromptForCredentials(string target, ref bool save, string message, string caption)
         {
-            var username = String.Empty;
-            var passwd = String.Empty;
-            var domain = String.Empty;
-
-            if (!PromptForCredentials(Target, ref save, Message, Caption, out username, out passwd, out domain))
-                return null;
-            return new NetworkCredential(username, passwd, domain);
+            string username, passwd, domain;
+            return PromptForCredentials(target, ref save, message, caption, out username, out passwd, out domain) ? new NetworkCredential(username, passwd, domain) : null;
         }
 
         /// <summary>
         /// Accepts credentials in a console window
         /// </summary>
-        /// <param name="Target">A descriptive text for where teh credentials being asked are used for</param>
+        /// <param name="target">A descriptive text for where teh credentials being asked are used for</param>
         /// <returns>NetworkCredential object containing the user name, </returns>
         public static NetworkCredential PromptForCredentialsConsole(string target)
         {
@@ -209,36 +199,36 @@ namespace AdysTech.CredentialManager
         /// <summary>
         /// Saves the given Network Credential into Windows Credential store
         /// </summary>
-        /// <param name="Target">Name of the application/Url where the credential is used for</param>
+        /// <param name="target">Name of the application/Url where the credential is used for</param>
         /// <param name="credential">Credential to store</param>
-        /// <returns>True:Success, False:Failure</returns>
-        public static bool SaveCredentials(string Target, NetworkCredential credential)
+        /// <returns>True:Success, throw if failed</returns>
+        public static bool SaveCredentials(string target, NetworkCredential credential)
         {
             // Go ahead with what we have are stuff it into the CredMan structures.
-            Credential cred = new Credential(credential);
-            cred.TargetName = Target;
-            cred.Persist = NativeCode.Persistance.Entrprise;
+            var cred = new Credential(credential)
+            {
+                TargetName = target, Persist = NativeCode.Persistance.Entrprise
+            };
             NativeCode.NativeCredential ncred = cred.GetNativeCredential();
+
             // Write the info into the CredMan storage.
-            bool written = NativeCode.CredWrite(ref ncred, 0);
-            int lastError = Marshal.GetLastWin32Error();
-            if (written)
+            if (NativeCode.CredWrite(ref ncred, 0))
             {
                 return true;
             }
-            else
-            {
-                string message = string.Format("'CredWrite' call throw an error (Error code: {0})", lastError);
-                throw new Exception(message);
-            }
+
+            int lastError = Marshal.GetLastWin32Error();
+            string message = String.Format("'CredWrite' call throw an error (Error code: {0})", lastError);
+            throw new Win32Exception(lastError, message);
         }
 
         /// <summary>
         /// Extract the stored credential from Windows Credential store
         /// </summary>
-        /// <param name="Target">Name of the application/Url where the credential is used for</param>
+        /// <param name="target">Name of the application/Url where the credential is used for</param>
+        /// <param name="type">Credential type</param>
         /// <returns>null if target not found, else stored credentials</returns>
-        public static NetworkCredential GetCredentials(string Target,CredentialType type = CredentialType.Generic)
+        public static NetworkCredential GetCredentials(string target, CredentialType type = CredentialType.Generic)
         {
             IntPtr nCredPtr;
             var username = String.Empty;
@@ -246,64 +236,63 @@ namespace AdysTech.CredentialManager
             var domain = String.Empty;
 
             // Make the API call using the P/Invoke signature
-
-            bool ret = NativeCode.CredRead(Target, (NativeCode.CredentialType) type, 0, out nCredPtr);
-            int lastError = Marshal.GetLastWin32Error();
-            if (!ret)
-                throw new Win32Exception(lastError, string.Format("'CredRead' call throw an error (Error code: {0})", lastError));
-            // If the API was successful then...
-            if (ret)
+            bool isSuccess = NativeCode.CredRead(target, (NativeCode.CredentialType) type, 0, out nCredPtr);
+            if (!isSuccess)
             {
-                try
-                {
+                var lastError = Marshal.GetLastWin32Error();
+                throw new Win32Exception(lastError,
+                    String.Format("'CredRead' call throw an error (Error code: {0})", lastError));
+            }
 
-                    using (CriticalCredentialHandle critCred = new CriticalCredentialHandle(nCredPtr))
+            try
+            {
+                using (CriticalCredentialHandle critCred = new CriticalCredentialHandle(nCredPtr))
+                {
+                    Credential cred = critCred.GetCredential();
+                    passwd = cred.CredentialBlob;
+                    if (!String.IsNullOrEmpty(cred.UserName))
                     {
-                        Credential cred = critCred.GetCredential();
-                        passwd = cred.CredentialBlob;
-                        if (!String.IsNullOrEmpty(cred.UserName))
-                        {
-                            var user = cred.UserName;
-                            StringBuilder userBuilder = new StringBuilder(cred.UserName.Length + 2);
-                            StringBuilder domainBuilder = new StringBuilder(cred.UserName.Length + 2);
+                        var user = cred.UserName;
+                        StringBuilder userBuilder = new StringBuilder(cred.UserName.Length + 2);
+                        StringBuilder domainBuilder = new StringBuilder(cred.UserName.Length + 2);
 
-                            var ret1 = NativeCode.CredUIParseUserName(user, userBuilder, userBuilder.Capacity, domainBuilder, domainBuilder.Capacity);
-                            lastError = Marshal.GetLastWin32Error();
+                        var returnCode = NativeCode.CredUIParseUserName(user, userBuilder, userBuilder.Capacity, domainBuilder, domainBuilder.Capacity);
+                        var lastError = Marshal.GetLastWin32Error();
 
-                            //assuming invalid account name to be not meeting condition for CredUIParseUserName
-                            //"The name must be in UPN or down-level format, or a certificate"
-                            if (ret1 == NativeCode.CredentialUIReturnCodes.InvalidAccountName)
-                                userBuilder.Append(user);
-                            else if ((uint)ret1 > 0)
-                                throw new Win32Exception(lastError, "CredUIParseUserName throw an error");
+                        //assuming invalid account name to be not meeting condition for CredUIParseUserName
+                        //"The name must be in UPN or down-level format, or a certificate"
+                        if (returnCode == NativeCode.CredentialUIReturnCodes.InvalidAccountName)
+                            userBuilder.Append(user);
+                        else if (returnCode != 0)
+                            throw new Win32Exception(lastError, String.Format("CredUIParseUserName throw an error (Error code: {0})", lastError));
 
-                            username = userBuilder.ToString();
-                            domain = domainBuilder.ToString();
-                        }
-                        return new NetworkCredential(username, passwd, domain);
+                        username = userBuilder.ToString();
+                        domain = domainBuilder.ToString();
                     }
-                }
-                catch(Exception e)
-                {
-                    return null;
+                    return new NetworkCredential(username, passwd, domain);
                 }
             }
-            return null;
+            catch(Exception)
+            {
+                return null;
+            }
         }
 
         /// <summary>
         /// Remove stored credentials from windows credential store
         /// </summary>
-        /// <param name="Target">Name of the application/Url where the credential is used for</param>
-        /// <returns>True: Success, False: Failure</returns>
-        public static bool RemoveCredentials(string Target)
+        /// <param name="target">Name of the application/Url where the credential is used for</param>
+        /// <returns>True: Success, throw if failed</returns>
+        public static bool RemoveCredentials(string target)
         {
             // Make the API call using the P/Invoke signature
-            var ret = NativeCode.CredDelete(Target, NativeCode.CredentialType.Generic, 0);
+            var isSuccess = NativeCode.CredDelete(target, NativeCode.CredentialType.Generic, 0);
+
+            if (isSuccess)
+                return true;
+
             int lastError = Marshal.GetLastWin32Error();
-            if (!ret)
-                throw new Win32Exception(lastError, string.Format("'CredDelete' call throw an error (Error code: {0})", lastError));
-            return ret;
+            throw new Win32Exception(lastError, String.Format("'CredDelete' call throw an error (Error code: {0})", lastError));
         }
 
         /// <summary>

--- a/AdysTech.CredentialManager/CredentialManager.cs
+++ b/AdysTech.CredentialManager/CredentialManager.cs
@@ -227,7 +227,7 @@ namespace AdysTech.CredentialManager
         /// </summary>
         /// <param name="target">Name of the application/Url where the credential is used for</param>
         /// <param name="type">Credential type</param>
-        /// <returns>null if target not found, else stored credentials</returns>
+        /// <returns>return the credentials if success, null if target not found, throw if failed to read stored credentials</returns>
         public static NetworkCredential GetCredentials(string target, CredentialType type = CredentialType.Generic)
         {
             IntPtr nCredPtr;
@@ -240,13 +240,15 @@ namespace AdysTech.CredentialManager
             if (!isSuccess)
             {
                 var lastError = Marshal.GetLastWin32Error();
+                if (lastError == (int) NativeCode.CredentialUIReturnCodes.NotFound)
+                    return null;
                 throw new Win32Exception(lastError,
                     String.Format("'CredRead' call throw an error (Error code: {0})", lastError));
             }
 
             try
             {
-                using (CriticalCredentialHandle critCred = new CriticalCredentialHandle(nCredPtr))
+                using (var critCred = new CriticalCredentialHandle(nCredPtr))
                 {
                     Credential cred = critCred.GetCredential();
                     passwd = cred.CredentialBlob;

--- a/AdysTech.CredentialManager/CredentialManager.cs
+++ b/AdysTech.CredentialManager/CredentialManager.cs
@@ -228,7 +228,7 @@ namespace AdysTech.CredentialManager
             }
             else
             {
-                string message = string.Format("CredWrite failed with the error code {0}.", lastError);
+                string message = string.Format("'CredWrite' call throw an error (Error code: {0})", lastError);
                 throw new Exception(message);
             }
         }
@@ -250,7 +250,7 @@ namespace AdysTech.CredentialManager
             bool ret = NativeCode.CredRead(Target, (NativeCode.CredentialType) type, 0, out nCredPtr);
             int lastError = Marshal.GetLastWin32Error();
             if (!ret)
-                throw new Win32Exception(lastError, "CredDelete throw an error");
+                throw new Win32Exception(lastError, string.Format("'CredRead' call throw an error (Error code: {0})", lastError));
             // If the API was successful then...
             if (ret)
             {
@@ -302,7 +302,7 @@ namespace AdysTech.CredentialManager
             var ret = NativeCode.CredDelete(Target, NativeCode.CredentialType.Generic, 0);
             int lastError = Marshal.GetLastWin32Error();
             if (!ret)
-                throw new Win32Exception(lastError, "CredDelete throw an error");
+                throw new Win32Exception(lastError, string.Format("'CredDelete' call throw an error (Error code: {0})", lastError));
             return ret;
         }
 

--- a/AdysTech.CredentialManager/Properties/AssemblyInfo.cs
+++ b/AdysTech.CredentialManager/Properties/AssemblyInfo.cs
@@ -2,11 +2,11 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("AdysTech.CredentialManager")]
-[assembly: AssemblyDescription("Library to to store and retreive User credentials from Windows Credential Store")]
+[assembly: AssemblyDescription("Library to store and retreive User credentials from Windows Credential Store")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("AdysTech")]
 [assembly: AssemblyProduct("AdysTech.CredentialManager")]
@@ -14,8 +14,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -25,12 +25,12 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.5.0")]
-[assembly: AssemblyFileVersion("1.4.5.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]


### PR DESCRIPTION
GetCredentials() now don't crash if credentials are not found

It is a nominal case to read not existing credentials,
so we should not throw and just return null

(Based on PR #22 , so should be merged after)