### PR TITLE
Add EnumerateCredentials. Create NetworkCredential extensions.

### DIFF
--- a/AdysTech.CredentialManager/AdysTech.CredentialManager.csproj
+++ b/AdysTech.CredentialManager/AdysTech.CredentialManager.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Credential.cs" />
+    <Compile Include="CredentialExtensions.cs" />
     <Compile Include="CredentialManager.cs" />
     <Compile Include="NativeCode.cs" />
     <Compile Include="CriticalCredentialHandle.cs" />

--- a/AdysTech.CredentialManager/Credential.cs
+++ b/AdysTech.CredentialManager/Credential.cs
@@ -42,7 +42,7 @@ namespace AdysTech.CredentialManager
             {
                 LastWritten = DateTime.FromFileTime((long)((ulong)ncred.LastWritten.dwHighDateTime << 32 | (ulong)ncred.LastWritten.dwLowDateTime));
             }
-            catch (ArgumentOutOfRangeException e)
+            catch (ArgumentOutOfRangeException)
             { }
         }
 

--- a/AdysTech.CredentialManager/CredentialExtensions.cs
+++ b/AdysTech.CredentialManager/CredentialExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.ComponentModel;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace AdysTech.CredentialManager
+{
+    internal static class CredentialExtensions
+    {
+        internal static NetworkCredential ToNetworkCredential(this Credential cred)
+        {
+            if (cred == null)
+            {
+                return null;
+            }
+
+            string username = string.Empty;
+            string domain = string.Empty;
+
+            var passwd = cred.CredentialBlob;
+
+            if (!string.IsNullOrEmpty(cred.UserName))
+            {
+                var user = cred.UserName;
+                var userBuilder = new StringBuilder(cred.UserName.Length + 2);
+                var domainBuilder = new StringBuilder(cred.UserName.Length + 2);
+
+                var returnCode = NativeCode.CredUIParseUserName(user, userBuilder, userBuilder.Capacity, domainBuilder, domainBuilder.Capacity);
+                var lastError = Marshal.GetLastWin32Error();
+
+                //assuming invalid account name to be not meeting condition for CredUIParseUserName
+                //"The name must be in UPN or down-level format, or a certificate"
+                if (returnCode == NativeCode.CredentialUIReturnCodes.InvalidAccountName)
+                {
+                    userBuilder.Append(user);
+                }
+                else if (returnCode != 0)
+                {
+                    throw new Win32Exception(lastError, String.Format("CredUIParseUserName throw an error (Error code: {0})", lastError));
+                }
+
+                username = userBuilder.ToString();
+                domain = domainBuilder.ToString();
+            }
+            return new NetworkCredential(username, passwd, domain);
+        }
+    }
+}

--- a/AdysTech.CredentialManager/CredentialManager.cs
+++ b/AdysTech.CredentialManager/CredentialManager.cs
@@ -314,6 +314,11 @@ namespace AdysTech.CredentialManager
             }
         }
 
+        /// <summary>
+        /// Enumerate the specified stored credentials in the Windows Credential store
+        /// </summary>
+        /// <param name="target">Name of the application or URL for which the credential is used</param>
+        /// <returns>Return a <see cref="List{NetworkCredential}"/> if success, null if target not found, throw if failed to read stored credentials</returns>
         public static List<NetworkCredential> EnumerateCredentials(string target = null)
         {
             IntPtr pCredentials = IntPtr.Zero;

--- a/AdysTech.CredentialManager/CriticalCredentialHandle.cs
+++ b/AdysTech.CredentialManager/CriticalCredentialHandle.cs
@@ -35,6 +35,29 @@ namespace AdysTech.CredentialManager
             }
         }
 
+        internal Credential[] EnumerateCredentials(uint size)
+        {
+            if (!IsInvalid)
+            {
+                var credentialArray = new Credential[size];
+
+                for (int i = 0; i < size; i++)
+                {
+                    IntPtr ptrPlc = Marshal.ReadIntPtr(handle, i * IntPtr.Size);
+
+                    var nc = (NativeCode.NativeCredential)Marshal.PtrToStructure(ptrPlc, typeof(NativeCode.NativeCredential));
+
+                    credentialArray[i] = new Credential(nc);
+                }
+
+                return credentialArray;
+            }
+            else
+            {
+                throw new InvalidOperationException("Invalid CriticalHandle!");
+            }
+        }
+
         // Perform any specific actions to release the handle in the ReleaseHandle method.
         // Often, you need to use Pinvoke to make a call into the Win32 API to release the 
         // handle. In this case, however, we can use the Marshal class to release the unmanaged memory.

--- a/AdysTech.CredentialManager/NativeCode.cs
+++ b/AdysTech.CredentialManager/NativeCode.cs
@@ -163,6 +163,9 @@ namespace AdysTech.CredentialManager
         [DllImport ("Advapi32.dll", EntryPoint = "CredDeleteW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern bool CredDelete(string target, CredentialType type, int reservedFlag);
 
+        [DllImport ("Advapi32.dll", EntryPoint = "CredEnumerateW", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern bool CredEnumerate(string target, UInt32 flags, out UInt32 count, out IntPtr credentialsPtr);
+
         [DllImport ("Advapi32.dll", EntryPoint = "CredReadW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern bool CredRead(string target, CredentialType type, int reservedFlag, out IntPtr CredentialPtr);
 

--- a/AdysTech.CredentialManager/Properties/AssemblyInfo.cs
+++ b/AdysTech.CredentialManager/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.0.0")]
-[assembly: AssemblyFileVersion("1.7.0.0")]
+[assembly: AssemblyVersion("1.8.0.0")]
+[assembly: AssemblyFileVersion("1.8.0.0")]
 
 [assembly: InternalsVisibleTo("CredentialManager.Test")] 

--- a/CredentialManager.Test/CredentialManagerTest.cs
+++ b/CredentialManager.Test/CredentialManagerTest.cs
@@ -69,7 +69,6 @@ namespace CredentialManagerTest
         /// <summary>
         /// This test assumes you have a Generic Credential for https://github.com stored on your system.
         /// </summary>
-        [TestMethod, TestCategory("AppVeyor")]
         public void TestEnumerateCredentialWithTarget()
         {
             try

--- a/CredentialManager.Test/CredentialManagerTest.cs
+++ b/CredentialManager.Test/CredentialManagerTest.cs
@@ -49,6 +49,43 @@ namespace CredentialManagerTest
             }
         }
 
+        [TestMethod, TestCategory("AppVeyor")]
+        public void TestEnumerateCredentials()
+        {
+            try
+            {
+                var creds = CredentialManager.EnumerateCredentials();
+                Assert.IsNotNull(creds, "EnumerateCredentials failed");
+                Assert.IsTrue(creds?.Count > 0, "No credentials stored in the system");
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Unexpected exception of type {0} caught: {1}",
+                            e.GetType(), e.Message);
+                return;
+            }
+        }
+
+        /// <summary>
+        /// This test assumes you have a Generic Credential for https://github.com stored on your system.
+        /// </summary>
+        [TestMethod, TestCategory("AppVeyor")]
+        public void TestEnumerateCredentialWithTarget()
+        {
+            try
+            {
+                var creds = CredentialManager.EnumerateCredentials(@"git:https://github.com");
+                Assert.IsNotNull(creds, "EnumerateCredentials failed");
+                Assert.IsTrue(creds?.Count > 0, "No credentials stored in the system");
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Unexpected exception of type {0} caught: {1}",
+                            e.GetType(), e.Message);
+                return;
+            }
+        }
+
         [TestMethod]
         public void TestPromptForCredentials()
         {


### PR DESCRIPTION
Added an EnumerateCredentials method that optionally takes a string target. This ultimately calls the exported EnumEnumerateW from Advapi32.dll. I also moved the functionality that created the System.Net.NetworkCredential object from the GetCredentials() method into its own extension method (and its own class) so that I could reuse it in the EnumerateCredentials() method.