### PR TITLE
Fix NullReferenceException when credentials not found

### DIFF
--- a/src/AdysTech.CredentialManager/CredentialManager.cs
+++ b/src/AdysTech.CredentialManager/CredentialManager.cs
@@ -274,7 +274,7 @@ namespace AdysTech.CredentialManager
         /// <returns>return the credentials if success, null if target not found, throw if failed to read stored credentials</returns>
         public static NetworkCredential GetCredentials(string target, CredentialType type = CredentialType.Generic)
         {
-            return (GetICredential(target, type) as Credential).ToNetworkCredential();
+            return (GetICredential(target, type) as Credential)?.ToNetworkCredential();
         }
 
         /// <summary>


### PR DESCRIPTION
Since version `2.0.0`, the method `CredentialManager.GetCredentials` throw a `NullReferenceException` if credentials with specified key does not exist.
I don't think that it's the expected behavior so I had a null check before converting to `NetworkCredential`.