### PR TITLE
Move back to netstandard2.0. Expose RemoveCredential method from ICredential 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ _Pvt_Extensions/
 ModelManifest.xml
 /.vs
 /.vs
+/.vscode/tasks.json

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
  <PropertyGroup>
    <Deterministic>true</Deterministic>
-   <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
+   <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
    <LangVersion>8</LangVersion>
    <PackageProjectUrl>https://github.com/AdysTech/CredentialManager</PackageProjectUrl>
     <RepositoryUrl>https://github.com/AdysTech/CredentialManager</RepositoryUrl>

--- a/src/AdysTech.CredentialManager/AdysTech.CredentialManager.csproj
+++ b/src/AdysTech.CredentialManager/AdysTech.CredentialManager.csproj
@@ -8,7 +8,7 @@
       2. Save Windows Generic Credentials
       3. Retrieve saved Windows Generic Credentials
       4. Add or edit ccomments, store additional attribute objects associated with Credentials</Description> 
-    <Version>2.2.0.0</Version>
+    <Version>2.3.0.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AdysTech.CredentialManager/Credential.cs
+++ b/src/AdysTech.CredentialManager/Credential.cs
@@ -110,7 +110,11 @@ namespace AdysTech.CredentialManager
             Persistance = credential.Persistance;
         }
 
-
+        public Credential(string target, CredentialType type)
+        {
+            Type = type;
+            TargetName = target;
+        }
 
         public NetworkCredential ToNetworkCredential()
         {
@@ -150,9 +154,9 @@ namespace AdysTech.CredentialManager
                 throw new ArgumentException("Comment can't be more than 256 bytes long", "Comment");
 
             if (String.IsNullOrEmpty(this.TargetName))
-                throw new ArgumentNullException("TargetName","TargetName can't be Null or Empty");
-            else if(this.TargetName.Length>32767)
-                throw new ArgumentNullException("TargetName can't be more than 32kB","TargetName");
+                throw new ArgumentNullException("TargetName", "TargetName can't be Null or Empty");
+            else if (this.TargetName.Length > 32767)
+                throw new ArgumentNullException("TargetName can't be more than 32kB", "TargetName");
 
             if (String.IsNullOrEmpty(this.CredentialBlob))
                 throw new ArgumentNullException("CredentialBlob", "CredentialBlob can't be Null or Empty");
@@ -262,6 +266,18 @@ namespace AdysTech.CredentialManager
                         Marshal.FreeHGlobal(buffer);
                 }
             }
+        }
+
+        public bool RemoveCredential()
+        {
+            // Make the API call using the P/Invoke signature
+            var isSuccess = NativeCode.CredDelete(TargetName, (uint)Type, 0);
+
+            if (isSuccess)
+                return true;
+
+            int lastError = Marshal.GetLastWin32Error();
+            throw new CredentialAPIException($"Unable to Delete Credential", "CredDelete", lastError);
         }
     }
 

--- a/src/AdysTech.CredentialManager/Credential.cs
+++ b/src/AdysTech.CredentialManager/Credential.cs
@@ -79,6 +79,7 @@ namespace AdysTech.CredentialManager
             }
             TargetAlias = ncred.TargetAlias;
             UserName = ncred.UserName;
+            Type = (CredentialType)ncred.Type;
         }
 
         public Credential(System.Net.NetworkCredential credential)

--- a/src/AdysTech.CredentialManager/CredentialManager.cs
+++ b/src/AdysTech.CredentialManager/CredentialManager.cs
@@ -333,14 +333,11 @@ namespace AdysTech.CredentialManager
         /// <returns>True: Success, throw if failed</returns>
         public static bool RemoveCredentials(string target, CredentialType type = CredentialType.Generic)
         {
-            // Make the API call using the P/Invoke signature
-            var isSuccess = NativeCode.CredDelete(target, (UInt32)type, 0);
-
-            if (isSuccess)
-                return true;
-
-            int lastError = Marshal.GetLastWin32Error();
-            throw new CredentialAPIException($"Unable to Delete Credential", "CredDelete", lastError);
+            var cred = new Credential(
+                target,
+                type
+            );
+            return cred.RemoveCredential();
         }
 
         /// <summary>

--- a/src/AdysTech.CredentialManager/ICredential.cs
+++ b/src/AdysTech.CredentialManager/ICredential.cs
@@ -21,5 +21,7 @@ namespace AdysTech.CredentialManager
 
         NetworkCredential ToNetworkCredential();
         bool SaveCredential();
+
+        bool RemoveCredential();
     }
 }

--- a/src/AdysTech.CredentialManager/PublicEnums.cs
+++ b/src/AdysTech.CredentialManager/PublicEnums.cs
@@ -1,13 +1,13 @@
 namespace AdysTech.CredentialManager
 {
-    public enum CredentialType
+    public enum CredentialType : uint
     {
         Generic = 1,
         Windows = 2,
         Certificate = 3
     }
 
-    public enum Persistance
+    public enum Persistance : uint
     {
         Session = 1,
         LocalMachine = 2,

--- a/tests/CredentialManager.Test/CredentialManagerTest.cs
+++ b/tests/CredentialManager.Test/CredentialManagerTest.cs
@@ -13,7 +13,7 @@ namespace CredentialManagerTest
         private const string uName = "ZYYM3ufm3kFY9ZJZUAqYFQfzxcRc9rzdYxUwqEhBqqdrHttrh";
         private const string pwd = "5NJuqKfJBtAZYYM3ufm3kFY9ZJZUAqYFQfzxcRc9rzdYxUwqEhBqqdrHttrhcvnnDPFHEn3L";
         private const string domain = "AdysTech.com";
-        
+
         [Serializable]
         struct SampleAttribute
         {
@@ -407,6 +407,22 @@ namespace CredentialManagerTest
             }
         }
 #endif
+
+        [TestMethod, TestCategory("AppVeyor")]
+        public void TestSaveCredentials_Generic()
+        {
+            var cred = new NetworkCredential("admin", "P@$$w0rd");
+            var saved = CredentialManager.SaveCredentials("TestGenericCredential", cred, CredentialType.Generic);
+            Assert.IsNotNull(saved, "SaveCredential on ICredential failed");
+
+            var cred1 = CredentialManager.GetICredential(saved.TargetName);
+            Assert.IsNotNull(cred1, "GetICredential failed");
+            Assert.IsTrue(cred1.UserName == saved.UserName, "Saved and retreived data doesn't match");
+            Assert.IsTrue(CredentialManager.RemoveCredentials(saved.TargetName, saved.Type), "RemoveCredentials returned false");
+
+            cred1 = CredentialManager.GetICredential(saved.TargetName);
+            Assert.IsNull(cred1, "Deleted credential was red");
+        }
 
     }
 }

--- a/tests/CredentialManager.Test/CredentialManagerTest.cs
+++ b/tests/CredentialManager.Test/CredentialManagerTest.cs
@@ -409,20 +409,31 @@ namespace CredentialManagerTest
 #endif
 
         [TestMethod, TestCategory("AppVeyor")]
-        public void TestSaveCredentials_Generic()
+        public void TestDeleteCredentials_Windows()
         {
             var cred = new NetworkCredential("admin", "P@$$w0rd");
-            var saved = CredentialManager.SaveCredentials("TestGenericCredential", cred, CredentialType.Generic);
+            var saved = CredentialManager.SaveCredentials("TestDeletingWindowsCredential", cred, CredentialType.Windows);
             Assert.IsNotNull(saved, "SaveCredential on ICredential failed");
 
-            var cred1 = CredentialManager.GetICredential(saved.TargetName);
+            var cred1 = CredentialManager.GetICredential(saved.TargetName, CredentialType.Windows);
             Assert.IsNotNull(cred1, "GetICredential failed");
             Assert.IsTrue(cred1.UserName == saved.UserName, "Saved and retreived data doesn't match");
             Assert.IsTrue(CredentialManager.RemoveCredentials(saved.TargetName, saved.Type), "RemoveCredentials returned false");
 
             cred1 = CredentialManager.GetICredential(saved.TargetName);
-            Assert.IsNull(cred1, "Deleted credential was red");
+            Assert.IsNull(cred1, "Deleted credential was read");
         }
 
+        [TestMethod, TestCategory("AppVeyor")]
+        public void TestDeleteCredentials_Enumerated()
+        {
+            var credentials = CredentialManager.EnumerateICredentials();
+
+            if (credentials != null)
+            {
+
+                credentials.ForEach(x => { if (x.Type == CredentialType.Windows) x.RemoveCredential(); });
+            }
+        }
     }
 }

--- a/tests/CredentialManager.Test/CredentialManagerTest.cs
+++ b/tests/CredentialManager.Test/CredentialManagerTest.cs
@@ -432,7 +432,7 @@ namespace CredentialManagerTest
             if (credentials != null)
             {
 
-                credentials.ForEach(x => { if (x.Type == CredentialType.Windows) x.RemoveCredential(); });
+                credentials.ForEach(x => { if (x.Type == CredentialType.Windows) Assert.IsTrue(x.RemoveCredential(),"RemoveCredentials returned false"); });
             }
         }
     }


### PR DESCRIPTION
Move back to netstandard2.0. Fixes #55 
Expose RemoveCredential method from ICredential. Add test case for RemoveCredential. Addressing #56 