### PR TITLE
Update max credential length to support tokens.

### DIFF
--- a/src/AdysTech.CredentialManager/AdysTech.CredentialManager.csproj
+++ b/src/AdysTech.CredentialManager/AdysTech.CredentialManager.csproj
@@ -8,7 +8,7 @@
       2. Save Windows Generic Credentials
       3. Retrieve saved Windows Generic Credentials
       4. Add or edit ccomments, store additional attribute objects associated with Credentials</Description> 
-    <Version>2.4.0.0</Version>
+    <Version>2.5.0.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/AdysTech.CredentialManager/Credential.cs
+++ b/src/AdysTech.CredentialManager/Credential.cs
@@ -36,7 +36,7 @@ namespace AdysTech.CredentialManager
         /// </summary>
         /// <remarks>
         /// This only controls the guard in the library. The actual underlying OS
-        /// controls the actual limit. Operations Systems older than Windows Server
+        /// controls the actual limit. Operating Systems older than Windows Server
         /// 2016 may only support 512 bytes.
         /// <para>
         /// Tokens often are 1040 bytes or more.

--- a/src/AdysTech.CredentialManager/Credential.cs
+++ b/src/AdysTech.CredentialManager/Credential.cs
@@ -25,6 +25,24 @@ namespace AdysTech.CredentialManager
         public UInt32 Flags;
         public string TargetAlias;
 
+        /// <summary>
+        /// Maximum size in bytes of a credential that can be stored. While the API 
+        /// documentation lists 512 as the max size, the current Windows SDK sets  
+        /// it to 5*512 via CRED_MAX_CREDENTIAL_BLOB_SIZE in wincred.h. This has 
+        /// been verified to work on Windows Server 2016 and later. 
+        /// <para>
+        /// API Doc: https://docs.microsoft.com/en-us/windows/win32/api/wincred/ns-wincred-credentiala
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// This only controls the guard in the library. The actual underlying OS
+        /// controls the actual limit. Operations Systems older than Windows Server
+        /// 2016 may only support 512 bytes.
+        /// <para>
+        /// Tokens often are 1040 bytes or more.
+        /// </para>
+        /// </remarks>
+        internal const int MaxCredentialBlobSize = 2560;
 
         internal Credential(NativeCode.NativeCredential ncred)
         {
@@ -172,8 +190,8 @@ namespace AdysTech.CredentialManager
                 TargetName = this.TargetName,
                 CredentialBlobSize = (UInt32)Encoding.Unicode.GetBytes(this.CredentialBlob).Length
             };
-            if (ncred.CredentialBlobSize > 512)
-                throw new ArgumentException($"Credential can't be more than 512 bytes long", "CredentialBlob");
+            if (ncred.CredentialBlobSize > MaxCredentialBlobSize)
+                throw new ArgumentException($"Credential can't be more than {MaxCredentialBlobSize} bytes long", "CredentialBlob");
 
             ncred.CredentialBlob = Marshal.StringToCoTaskMemUni(this.CredentialBlob);
             if (this.LastWritten != DateTime.MinValue)


### PR DESCRIPTION
Tokens often exceed 1000 bytes. The Windows SDK indicates that support in the credential manager has been expanded to 5*512 bytes.

This change increases the guard checking the parameter. It documents the maximum. Unit test created to verify that tokens of a typical size are supported.

Change has been verified on Windows Server 2016, Windows 10, and Windows Server 2019.

Addresses issue #65 